### PR TITLE
Add the all method to the Paginated response

### DIFF
--- a/examples/customers-all.rs
+++ b/examples/customers-all.rs
@@ -1,0 +1,14 @@
+use paddle_rust_sdk::Paddle;
+
+#[tokio::main]
+async fn main() {
+    let client = Paddle::new(std::env::var("PADDLE_API_KEY").unwrap(), Paddle::SANDBOX).unwrap();
+
+    let mut list = client.customers_list();
+    let mut paginated = list.per_page(1).send();
+    let customers = paginated.all().await.unwrap();
+
+    for customer in customers {
+        dbg!(customer);
+    }
+}

--- a/src/paginated.rs
+++ b/src/paginated.rs
@@ -59,3 +59,16 @@ where
         }
     }
 }
+
+impl<'a, I> Paginated<'a, Vec<I>>
+where
+    I: DeserializeOwned,
+{
+    pub async fn all(&mut self) -> Result<Vec<I>, Error> {
+        let mut collected = Vec::new();
+        while let Some(response) = self.next().await? {
+            collected.extend(response.data.into_iter());
+        }
+        Ok(collected)
+    }
+}


### PR DESCRIPTION
Hi! Thank you for updating the crate with paginated responses :fire:
I've added one more method to the `Paginated` struct to collect `all()` values into a single `Vec`.
And an example `customers-all.rs` that uses the new method.

cc @peterprototypes 