### PR TITLE
Derive Eq, Ord and Hash for ids and enums

### DIFF
--- a/src/enums.rs
+++ b/src/enums.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::reports::ReportType;
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 pub enum CountryCodeSupported {
     /// Andorra
@@ -470,7 +470,7 @@ pub enum CountryCodeSupported {
 }
 
 /// Whether this entity can be used in Paddle.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 #[serde(rename_all = "kebab-case")]
 pub enum Status {
@@ -481,7 +481,7 @@ pub enum Status {
 }
 
 /// How this adjustment impacts the related transaction.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 pub enum AdjustmentAction {
@@ -500,7 +500,7 @@ pub enum AdjustmentAction {
 }
 
 /// Type of adjustment. Use `full` to adjust the grand total for the related transaction. Include an `items` array when creating a `partial` adjustment. If omitted, defaults to `partial`.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 #[serde(rename_all = "lowercase")]
 pub enum AdjustmentType {
@@ -511,7 +511,7 @@ pub enum AdjustmentType {
 }
 
 /// Supported three-letter ISO 4217 currency code.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 pub enum CurrencyCode {
     /// United States Dollar
@@ -583,7 +583,7 @@ pub enum CurrencyCode {
 /// Most refunds for live accounts are created with the status of `pending_approval` until reviewed by Paddle, but some are automatically approved. For sandbox accounts, Paddle automatically approves refunds every ten minutes.
 ///
 /// Credit adjustments don't require approval from Paddle, so they're created as `approved`.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 pub enum AdjustmentStatus {
@@ -598,7 +598,7 @@ pub enum AdjustmentStatus {
 }
 
 /// Three-letter ISO 4217 currency code for chargeback fees.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 pub enum CurrencyCodeChargebacks {
     /// Australian Dollar
@@ -614,7 +614,7 @@ pub enum CurrencyCodeChargebacks {
 }
 
 /// Supported three-letter ISO 4217 currency code for payouts from Paddle.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 pub enum CurrencyCodePayouts {
     /// Australian Dollar
@@ -647,7 +647,7 @@ pub enum CurrencyCodePayouts {
 
 /// Type of adjustment for this transaction item. `tax` adjustments are automatically created by Paddle.
 /// Include `amount` when creating a `partial` adjustment.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 #[serde(rename_all = "lowercase")]
 pub enum AdjustmentItemType {
@@ -662,7 +662,7 @@ pub enum AdjustmentItemType {
 }
 
 /// Unit of time.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 #[serde(rename_all = "kebab-case")]
 pub enum Interval {
@@ -673,7 +673,7 @@ pub enum Interval {
 }
 
 /// Type of credit or debit card used to pay.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 pub enum CardType {
@@ -700,7 +700,7 @@ pub enum CardType {
 }
 
 /// Type of item. Standard items are considered part of your catalog and are shown on the Paddle dashboard.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 #[serde(rename_all = "kebab-case")]
 pub enum CatalogType {
@@ -711,7 +711,7 @@ pub enum CatalogType {
 }
 
 /// How payment is collected. `automatic` for checkout, `manual` for invoices.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 pub enum CollectionMode {
@@ -722,7 +722,7 @@ pub enum CollectionMode {
 }
 
 /// Type of payment method saved.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 pub enum SavedPaymentMethodType {
@@ -739,7 +739,7 @@ pub enum SavedPaymentMethodType {
 }
 
 /// Describes how this payment method was saved.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 pub enum PaymentMethodOrigin {
@@ -750,7 +750,7 @@ pub enum PaymentMethodOrigin {
 }
 
 /// Whether this entity can be used in Paddle.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 #[serde(rename_all = "kebab-case")]
 pub enum DiscountStatus {
@@ -761,7 +761,7 @@ pub enum DiscountStatus {
 }
 
 /// Type of discount. Determines how this discount impacts the checkout or transaction total.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 pub enum DiscountType {
@@ -775,7 +775,7 @@ pub enum DiscountType {
 
 /// When this subscription change should take effect from. Defaults to `next_billing_period`, which creates a
 /// `scheduled_change` to apply the subscription change at the end of the billing period.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 pub enum EffectiveFrom {
@@ -786,7 +786,7 @@ pub enum EffectiveFrom {
 }
 
 /// Type of error encountered.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 pub enum Type {
     /// Typically means there's a problem with the request that you made.
@@ -796,7 +796,7 @@ pub enum Type {
 }
 
 /// Reason why a payment attempt failed. Returns `null` if payment captured successfully.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 pub enum ErrorCode {
@@ -841,7 +841,7 @@ pub enum ErrorCode {
 }
 
 /// Type of event sent by Paddle, in the format `entity.event_type`.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 pub enum EventTypeName {
     /// An [`address.created`](https://developer.paddle.com/webhooks/addresses/address-created) event.
@@ -1088,7 +1088,7 @@ pub enum EventData {
 }
 
 /// Status of this subscription item. Set automatically by Paddle.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 #[serde(rename_all = "lowercase")]
 pub enum SubscriptionItemStatus {
@@ -1101,7 +1101,7 @@ pub enum SubscriptionItemStatus {
 }
 
 /// How tax is calculated for this price.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 pub enum TaxMode {
@@ -1114,7 +1114,7 @@ pub enum TaxMode {
 }
 
 /// Tax category for this product. Used for charging the correct rate of tax. Selected tax category must be enabled on your Paddle account.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 #[serde(rename_all = "kebab-case")]
 pub enum TaxCategory {
@@ -1155,7 +1155,7 @@ impl AsRef<str> for TaxCategory {
 }
 
 /// Type of payment method used for this payment attempt.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 pub enum PaymentMethodType {
@@ -1182,7 +1182,7 @@ pub enum PaymentMethodType {
 }
 
 /// Status of this notification.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 pub enum NotificationStatus {
     /// Paddle hasn't yet tried to deliver this notification.
@@ -1196,7 +1196,7 @@ pub enum NotificationStatus {
 }
 
 /// Describes how this notification was created.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 pub enum NotificationOrigin {
     /// Notification created when a subscribed event occurred.
@@ -1206,7 +1206,7 @@ pub enum NotificationOrigin {
 }
 
 /// Where notifications should be sent for this destination.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 pub enum NotificationSettingType {
     /// Deliver to an email address.
@@ -1216,7 +1216,7 @@ pub enum NotificationSettingType {
 }
 
 /// Whether Paddle should deliver real platform events, simulation events or both to this notification destination.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 pub enum TrafficSource {
     /// Deliver real platform events to this notification destination.
@@ -1228,7 +1228,7 @@ pub enum TrafficSource {
 }
 
 /// Operator to use when filtering.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 #[serde(rename_all = "lowercase")]
 pub enum FilterOperator {
@@ -1238,7 +1238,7 @@ pub enum FilterOperator {
     Gte,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 pub enum TransactionOrigin {
@@ -1259,7 +1259,7 @@ pub enum TransactionOrigin {
 /// Status of this report. Set automatically by Paddle.
 ///
 /// Reports are created as `pending` initially, then move to `ready` when they're available to download.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 pub enum ReportStatus {
@@ -1274,7 +1274,7 @@ pub enum ReportStatus {
 }
 
 /// Field name to filter by.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 pub enum AdjustmentsReportFilterName {
@@ -1289,7 +1289,7 @@ pub enum AdjustmentsReportFilterName {
 }
 
 /// Field name to filter by.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 pub enum DiscountsReportFilterName {
@@ -1302,7 +1302,7 @@ pub enum DiscountsReportFilterName {
 }
 
 /// Field name to filter by.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 pub enum BalanceReportFilterName {
@@ -1311,7 +1311,7 @@ pub enum BalanceReportFilterName {
 }
 
 /// Field name to filter by.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 pub enum ProductPricesReportFilterName {
@@ -1330,7 +1330,7 @@ pub enum ProductPricesReportFilterName {
 }
 
 /// Field name to filter by.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 pub enum TransactionsReportFilterName {
@@ -1347,7 +1347,7 @@ pub enum TransactionsReportFilterName {
 }
 
 /// Type of report.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 pub enum AdjustmentsReportType {
@@ -1362,7 +1362,7 @@ impl ReportType for AdjustmentsReportType {
 }
 
 /// Type of report.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 pub enum TransactionsReportType {
@@ -1377,7 +1377,7 @@ impl ReportType for TransactionsReportType {
 }
 
 /// Type of report.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 pub enum ProductsAndPricesReportType {
@@ -1390,7 +1390,7 @@ impl ReportType for ProductsAndPricesReportType {
 }
 
 /// Type of report.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 pub enum DiscountsReportType {
@@ -1403,7 +1403,7 @@ impl ReportType for DiscountsReportType {
 }
 
 /// Type of report.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 pub enum BalanceReportType {
@@ -1416,7 +1416,7 @@ impl ReportType for BalanceReportType {
 }
 
 /// Status of this simulation run log.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 pub enum SimulationEventStatus {
     /// Simulation run log is pending. Paddle hasn't yet tried to deliver the simulated event.
@@ -1430,7 +1430,7 @@ pub enum SimulationEventStatus {
 }
 
 /// Status of this simulation run.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 pub enum SimulationRunStatus {
     /// Simulation run is pending. Paddle is sending events that are part of this simulation.
@@ -1442,7 +1442,7 @@ pub enum SimulationRunStatus {
 }
 
 /// Scenario for a simulation.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 pub enum SimulationScenarioType {
     /// Simulates all events sent when a subscription is created.
@@ -1458,7 +1458,7 @@ pub enum SimulationScenarioType {
 }
 
 /// Type of simulation.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 pub enum SimulationKind {
     /// Paddle simulates a single event.
@@ -1468,7 +1468,7 @@ pub enum SimulationKind {
 }
 
 /// Status of this payment attempt.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 pub enum PaymentAttemptStatus {
@@ -1495,7 +1495,7 @@ pub enum PaymentAttemptStatus {
 }
 
 /// Status of this subscription. Set automatically by Paddle. Use the pause subscription or cancel subscription operations to change.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 pub enum SubscriptionStatus {
@@ -1512,7 +1512,7 @@ pub enum SubscriptionStatus {
 }
 
 /// Status of this transaction. You may set a transaction to `billed` or `canceled`, other statuses are set automatically by Paddle. Automatically-collected transactions may return `completed` if payment is captured successfully, or `past_due` if payment failed.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 pub enum TransactionStatus {
@@ -1533,7 +1533,7 @@ pub enum TransactionStatus {
 }
 
 /// Kind of change that's scheduled to be applied to this subscription.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 #[serde(rename_all = "lowercase")]
 pub enum ScheduledChangeAction {
@@ -1546,7 +1546,7 @@ pub enum ScheduledChangeAction {
 }
 
 /// How Paddle should handle changes made to a subscription or its items if the payment fails during update. If omitted, defaults to `prevent_change`.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 pub enum SubscriptionOnPaymentFailure {
@@ -1557,7 +1557,7 @@ pub enum SubscriptionOnPaymentFailure {
 }
 
 /// Whether the subscription change results in a prorated credit or a charge.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 #[serde(rename_all = "lowercase")]
 pub enum UpdateSummaryResultAction {
@@ -1572,7 +1572,7 @@ pub enum UpdateSummaryResultAction {
 ///
 /// For automatically-collected subscriptions, responses may take longer than usual if a proration billing mode that
 /// collects for payment immediately is used.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 pub enum ProrationBillingMode {
@@ -1593,7 +1593,7 @@ pub enum ProrationBillingMode {
 }
 
 /// How Paddle should set the billing period for the subscription when resuming. If omitted, defaults to `start_new_billing_period`.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 pub enum SubscriptionOnResume {
@@ -1604,7 +1604,7 @@ pub enum SubscriptionOnResume {
 }
 
 /// Determine whether the generated URL should download the PDF as an attachment saved locally, or open it inline in the browser.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 #[serde(rename_all = "lowercase")]
 pub enum Disposition {
@@ -1614,7 +1614,7 @@ pub enum Disposition {
     Inline,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 #[serde(rename_all = "lowercase")]
 pub enum PayoutStatus {
@@ -1624,7 +1624,7 @@ pub enum PayoutStatus {
     Unpaid,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 #[serde(rename_all = "lowercase")]
 pub enum ApiKeyStatus {

--- a/src/ids.rs
+++ b/src/ids.rs
@@ -4,275 +4,151 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-/// Unique Paddle ID for this address entity, prefixed with `add_`.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct AddressID(String);
+macro_rules! paddle_id {
+    ($(#[$attr:meta])* $name:ident) => {
+        $(#[$attr])*
+        #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        pub struct $name(pub String);
 
-impl<T: Display> From<T> for AddressID {
-    fn from(value: T) -> Self {
-        AddressID(value.to_string())
-    }
+        impl<T: Display> From<T> for $name {
+            fn from(value: T) -> Self {
+                $name(value.to_string())
+            }
+        }
+
+        impl AsRef<str> for $name {
+            fn as_ref(&self) -> &str {
+                &self.0
+            }
+        }
+    };
 }
 
-impl AsRef<str> for AddressID {
-    fn as_ref(&self) -> &str {
-        &self.0
-    }
+paddle_id! {
+    /// Unique Paddle ID for this address entity, prefixed with `add_`.
+    AddressID
 }
 
-/// Unique Paddle ID for this customer entity, prefixed with `ctm_`.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct CustomerID(String);
-
-impl<T: Display> From<T> for CustomerID {
-    fn from(value: T) -> Self {
-        CustomerID(value.to_string())
-    }
+paddle_id! {
+    /// Unique Paddle ID for this customer entity, prefixed with `ctm_`.
+    CustomerID
 }
 
-impl AsRef<str> for CustomerID {
-    fn as_ref(&self) -> &str {
-        &self.0
-    }
+paddle_id! {
+    /// Unique Paddle ID for this adjustment entity, prefixed with `adj_`.
+    AdjustmentID
 }
 
-/// Unique Paddle ID for this adjustment entity, prefixed with `adj_`.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct AdjustmentID(String);
-
-impl<T: Display> From<T> for AdjustmentID {
-    fn from(value: T) -> Self {
-        AdjustmentID(value.to_string())
-    }
+paddle_id! {
+    /// Unique Paddle ID for this transaction entity, prefixed with `txn_`.
+    TransactionID
+}
+paddle_id! {
+    /// Unique Paddle ID for this subscription entity, prefixed with `sub_`.
+    SubscriptionID
 }
 
-impl AsRef<str> for AdjustmentID {
-    fn as_ref(&self) -> &str {
-        &self.0
-    }
+paddle_id! {
+    /// Unique Paddle ID for this transaction item, prefixed with `txnitm_`. Used when working with [adjustments](https://developer.paddle.com/build/transactions/create-transaction-adjustments).
+    TransactionItemID
 }
 
-/// Unique Paddle ID for this transaction entity, prefixed with `txn_`.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct TransactionID(String);
-
-impl<T: Display> From<T> for TransactionID {
-    fn from(value: T) -> Self {
-        TransactionID(value.to_string())
-    }
+paddle_id! {
+    /// Unique Paddle ID for this adjustment item, prefixed with `adjitm_`.
+    AdjustmentItemID
 }
 
-impl AsRef<str> for TransactionID {
-    fn as_ref(&self) -> &str {
-        &self.0
-    }
-}
-/// Unique Paddle ID for this subscription entity, prefixed with `sub_`.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct SubscriptionID(String);
-
-impl<T: Display> From<T> for SubscriptionID {
-    fn from(value: T) -> Self {
-        SubscriptionID(value.to_string())
-    }
+paddle_id! {
+    /// Unique Paddle ID for this business entity, prefixed with `biz_`.
+    BusinessID
 }
 
-impl AsRef<str> for SubscriptionID {
-    fn as_ref(&self) -> &str {
-        &self.0
-    }
+paddle_id! {
+    /// Unique Paddle ID for this payment method entity, prefixed with `paymtd_`.
+    PaymentMethodID
 }
 
-/// Unique Paddle ID for this transaction item, prefixed with `txnitm_`. Used when working with [adjustments](https://developer.paddle.com/build/transactions/create-transaction-adjustments).
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct TransactionItemID(String);
-
-/// Unique Paddle ID for this adjustment item, prefixed with `adjitm_`.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct AdjustmentItemID(String);
-
-/// Unique Paddle ID for this business entity, prefixed with `biz_`.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct BusinessID(String);
-
-impl<T: Display> From<T> for BusinessID {
-    fn from(value: T) -> Self {
-        BusinessID(value.to_string())
-    }
+paddle_id! {
+    /// Unique Paddle ID for this customer portal session entity, prefixed with `cpls_`.
+    CustomerPortalSessionID
 }
 
-impl AsRef<str> for BusinessID {
-    fn as_ref(&self) -> &str {
-        &self.0
-    }
+paddle_id! {
+    /// Unique Paddle ID for this discount, prefixed with `dsc_`.
+    DiscountID
 }
 
-/// Unique Paddle ID for this payment method entity, prefixed with `paymtd_`.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct PaymentMethodID(String);
-
-impl<T: Display> From<T> for PaymentMethodID {
-    fn from(value: T) -> Self {
-        PaymentMethodID(value.to_string())
-    }
+paddle_id! {
+    /// Unique code that customers can use to apply this discount at checkout. Use letters and numbers only, up to 16 characters. Not case-sensitive.
+    DiscountCode
 }
 
-impl AsRef<str> for PaymentMethodID {
-    fn as_ref(&self) -> &str {
-        &self.0
-    }
+paddle_id! {
+    /// Unique Paddle ID for this event, prefixed with `evt_`.
+    EventID
 }
 
-/// Unique Paddle ID for this customer portal session entity, prefixed with `cpls_`.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct CustomerPortalSessionID(String);
-
-/// Unique Paddle ID for this discount, prefixed with `dsc_`.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct DiscountID(String);
-
-impl<T: Display> From<T> for DiscountID {
-    fn from(value: T) -> Self {
-        DiscountID(value.to_string())
-    }
+paddle_id! {
+    /// Unique Paddle ID for this price, prefixed with `pri_`.
+    PriceID
 }
 
-impl AsRef<str> for DiscountID {
-    fn as_ref(&self) -> &str {
-        &self.0
-    }
+paddle_id! {
+    /// Unique Paddle ID for this product, prefixed with `pro_`.
+    ProductID
 }
 
-/// Unique code that customers can use to apply this discount at checkout. Use letters and numbers only, up to 16 characters. Not case-sensitive.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct DiscountCode(String);
-
-/// Unique Paddle ID for this event, prefixed with `evt_`.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct EventID(String);
-
-impl<T: Display> From<T> for EventID {
-    fn from(value: T) -> Self {
-        EventID(value.to_string())
-    }
+paddle_id! {
+    /// Unique Paddle ID for API keys, prefixed with `apikey_`.
+    ApiKeyID
 }
 
-impl AsRef<str> for EventID {
-    fn as_ref(&self) -> &str {
-        &self.0
-    }
+paddle_id! {
+    /// Unique Paddle ID for payouts, prefixed with `payout_`.
+    PayoutID
 }
 
-/// Unique Paddle ID for this price, prefixed with `pri_`.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct PriceID(String);
-
-impl<T: Display> From<T> for PriceID {
-    fn from(value: T) -> Self {
-        PriceID(value.to_string())
-    }
+paddle_id! {
+    /// Unique Paddle ID for this notification, prefixed with `ntf_`.
+    NotificationID
 }
 
-impl AsRef<str> for PriceID {
-    fn as_ref(&self) -> &str {
-        &self.0
-    }
+paddle_id! {
+    /// Unique Paddle ID for this notification setting, prefixed with `ntfset_`.
+    NotificationSettingID
 }
 
-/// Unique Paddle ID for this product, prefixed with `pro_`.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct ProductID(pub String);
-
-impl<T: Display> From<T> for ProductID {
-    fn from(value: T) -> Self {
-        ProductID(value.to_string())
-    }
+paddle_id! {
+    /// Unique Paddle ID for this notification log, prefixed with `ntflog_`.
+    NotificationLogID
 }
 
-// Needed for serialization to comma separated values
-impl AsRef<str> for ProductID {
-    fn as_ref(&self) -> &str {
-        &self.0
-    }
+paddle_id! {
+    /// Webhook destination secret key, prefixed with `pdl_ntfset_`. Used for signature verification.
+    EndpointSecretKey
 }
 
-/// Unique Paddle ID for API keys, prefixed with `apikey_`.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct ApiKeyID(pub String);
-
-impl<T: Display> From<T> for ApiKeyID {
-    fn from(value: T) -> Self {
-        ApiKeyID(value.to_string())
-    }
+paddle_id! {
+    /// Just a Paddle ID. I've noticed this used in some places.
+    PaddleID
 }
 
-impl AsRef<str> for ApiKeyID {
-    fn as_ref(&self) -> &str {
-        &self.0
-    }
+paddle_id! {
+    /// Unique Paddle ID for this simulation event, prefixed with `ntfsimevt_`.
+    SimulationEventID
 }
 
-/// Unique Paddle ID for payouts, prefixed with `payout_`.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct PayoutID(pub String);
-
-impl<T: Display> From<T> for PayoutID {
-    fn from(value: T) -> Self {
-        PayoutID(value.to_string())
-    }
+paddle_id! {
+    /// Unique Paddle ID for this simulation run, prefixed with `ntfsimrun_`.
+    SimulationRunID
 }
 
-impl AsRef<str> for PayoutID {
-    fn as_ref(&self) -> &str {
-        &self.0
-    }
+paddle_id! {
+    /// Unique Paddle ID for this simulation, prefixed with `ntfsim_`.
+    SimulationID
 }
 
-/// Unique Paddle ID for this notification, prefixed with `ntf_`.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct NotificationID(String);
-
-/// Unique Paddle ID for this notification setting, prefixed with `ntfset_`.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct NotificationSettingID(String);
-
-/// Unique Paddle ID for this notification log, prefixed with `ntflog_`.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct NotificationLogID(String);
-
-/// Webhook destination secret key, prefixed with `pdl_ntfset_`. Used for signature verification.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct EndpointSecretKey(String);
-
-/// Just a Paddle ID. I've noticed this used in some places.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct PaddleID(String);
-
-impl<T: Display> From<T> for PaddleID {
-    fn from(value: T) -> Self {
-        PaddleID(value.to_string())
-    }
+paddle_id! {
+    /// Paddle ID of the invoice that this transaction is related to, prefixed with `inv_`. Used for compatibility with the Paddle Invoice API, which is now deprecated. This field is scheduled to be removed in the next version of the Paddle API.
+    InvoiceId
 }
-
-// Needed for serialization to comma separated values
-impl AsRef<str> for PaddleID {
-    fn as_ref(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Unique Paddle ID for this simulation event, prefixed with `ntfsimevt_`.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct SimulationEventID(String);
-
-/// Unique Paddle ID for this simulation run, prefixed with `ntfsimrun_`.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct SimulationRunID(String);
-
-/// Unique Paddle ID for this simulation, prefixed with `ntfsim_`.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct SimulationID(String);
-
-/// Paddle ID of the invoice that this transaction is related to, prefixed with `inv_`. Used for compatibility with the Paddle Invoice API, which is now deprecated. This field is scheduled to be removed in the next version of the Paddle API.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct InvoiceId(String);

--- a/src/ids.rs
+++ b/src/ids.rs
@@ -5,7 +5,7 @@ use std::fmt::Display;
 use serde::{Deserialize, Serialize};
 
 /// Unique Paddle ID for this address entity, prefixed with `add_`.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AddressID(String);
 
 impl<T: Display> From<T> for AddressID {
@@ -21,7 +21,7 @@ impl AsRef<str> for AddressID {
 }
 
 /// Unique Paddle ID for this customer entity, prefixed with `ctm_`.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CustomerID(String);
 
 impl<T: Display> From<T> for CustomerID {
@@ -37,7 +37,7 @@ impl AsRef<str> for CustomerID {
 }
 
 /// Unique Paddle ID for this adjustment entity, prefixed with `adj_`.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AdjustmentID(String);
 
 impl<T: Display> From<T> for AdjustmentID {
@@ -53,7 +53,7 @@ impl AsRef<str> for AdjustmentID {
 }
 
 /// Unique Paddle ID for this transaction entity, prefixed with `txn_`.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct TransactionID(String);
 
 impl<T: Display> From<T> for TransactionID {
@@ -68,7 +68,7 @@ impl AsRef<str> for TransactionID {
     }
 }
 /// Unique Paddle ID for this subscription entity, prefixed with `sub_`.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SubscriptionID(String);
 
 impl<T: Display> From<T> for SubscriptionID {
@@ -84,15 +84,15 @@ impl AsRef<str> for SubscriptionID {
 }
 
 /// Unique Paddle ID for this transaction item, prefixed with `txnitm_`. Used when working with [adjustments](https://developer.paddle.com/build/transactions/create-transaction-adjustments).
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct TransactionItemID(String);
 
 /// Unique Paddle ID for this adjustment item, prefixed with `adjitm_`.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AdjustmentItemID(String);
 
 /// Unique Paddle ID for this business entity, prefixed with `biz_`.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BusinessID(String);
 
 impl<T: Display> From<T> for BusinessID {
@@ -108,7 +108,7 @@ impl AsRef<str> for BusinessID {
 }
 
 /// Unique Paddle ID for this payment method entity, prefixed with `paymtd_`.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PaymentMethodID(String);
 
 impl<T: Display> From<T> for PaymentMethodID {
@@ -124,11 +124,11 @@ impl AsRef<str> for PaymentMethodID {
 }
 
 /// Unique Paddle ID for this customer portal session entity, prefixed with `cpls_`.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CustomerPortalSessionID(String);
 
 /// Unique Paddle ID for this discount, prefixed with `dsc_`.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DiscountID(String);
 
 impl<T: Display> From<T> for DiscountID {
@@ -144,11 +144,11 @@ impl AsRef<str> for DiscountID {
 }
 
 /// Unique code that customers can use to apply this discount at checkout. Use letters and numbers only, up to 16 characters. Not case-sensitive.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DiscountCode(String);
 
 /// Unique Paddle ID for this event, prefixed with `evt_`.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct EventID(String);
 
 impl<T: Display> From<T> for EventID {
@@ -164,7 +164,7 @@ impl AsRef<str> for EventID {
 }
 
 /// Unique Paddle ID for this price, prefixed with `pri_`.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PriceID(String);
 
 impl<T: Display> From<T> for PriceID {
@@ -180,7 +180,7 @@ impl AsRef<str> for PriceID {
 }
 
 /// Unique Paddle ID for this product, prefixed with `pro_`.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ProductID(pub String);
 
 impl<T: Display> From<T> for ProductID {
@@ -197,7 +197,7 @@ impl AsRef<str> for ProductID {
 }
 
 /// Unique Paddle ID for API keys, prefixed with `apikey_`.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ApiKeyID(pub String);
 
 impl<T: Display> From<T> for ApiKeyID {
@@ -213,7 +213,7 @@ impl AsRef<str> for ApiKeyID {
 }
 
 /// Unique Paddle ID for payouts, prefixed with `payout_`.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PayoutID(pub String);
 
 impl<T: Display> From<T> for PayoutID {
@@ -229,23 +229,23 @@ impl AsRef<str> for PayoutID {
 }
 
 /// Unique Paddle ID for this notification, prefixed with `ntf_`.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct NotificationID(String);
 
 /// Unique Paddle ID for this notification setting, prefixed with `ntfset_`.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct NotificationSettingID(String);
 
 /// Unique Paddle ID for this notification log, prefixed with `ntflog_`.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct NotificationLogID(String);
 
 /// Webhook destination secret key, prefixed with `pdl_ntfset_`. Used for signature verification.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct EndpointSecretKey(String);
 
 /// Just a Paddle ID. I've noticed this used in some places.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PaddleID(String);
 
 impl<T: Display> From<T> for PaddleID {
@@ -262,17 +262,17 @@ impl AsRef<str> for PaddleID {
 }
 
 /// Unique Paddle ID for this simulation event, prefixed with `ntfsimevt_`.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SimulationEventID(String);
 
 /// Unique Paddle ID for this simulation run, prefixed with `ntfsimrun_`.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SimulationRunID(String);
 
 /// Unique Paddle ID for this simulation, prefixed with `ntfsim_`.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SimulationID(String);
 
 /// Paddle ID of the invoice that this transaction is related to, prefixed with `inv_`. Used for compatibility with the Paddle Invoice API, which is now deprecated. This field is scheduled to be removed in the next version of the Paddle API.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct InvoiceId(String);

--- a/src/ids.rs
+++ b/src/ids.rs
@@ -22,133 +22,92 @@ macro_rules! paddle_id {
             }
         }
     };
+    ($($(#[$attr:meta])* $name:ident,)*) => {
+        $(
+            paddle_id! {
+                $(#[$attr])*
+                $name
+            }
+        )*
+    };
 }
 
 paddle_id! {
     /// Unique Paddle ID for this address entity, prefixed with `add_`.
-    AddressID
-}
+    AddressID,
 
-paddle_id! {
     /// Unique Paddle ID for this customer entity, prefixed with `ctm_`.
-    CustomerID
-}
+    CustomerID,
 
-paddle_id! {
     /// Unique Paddle ID for this adjustment entity, prefixed with `adj_`.
-    AdjustmentID
-}
+    AdjustmentID,
 
-paddle_id! {
     /// Unique Paddle ID for this transaction entity, prefixed with `txn_`.
-    TransactionID
-}
-paddle_id! {
+    TransactionID,
+
     /// Unique Paddle ID for this subscription entity, prefixed with `sub_`.
-    SubscriptionID
-}
+    SubscriptionID,
 
-paddle_id! {
     /// Unique Paddle ID for this transaction item, prefixed with `txnitm_`. Used when working with [adjustments](https://developer.paddle.com/build/transactions/create-transaction-adjustments).
-    TransactionItemID
-}
+    TransactionItemID,
 
-paddle_id! {
     /// Unique Paddle ID for this adjustment item, prefixed with `adjitm_`.
-    AdjustmentItemID
-}
+    AdjustmentItemID,
 
-paddle_id! {
     /// Unique Paddle ID for this business entity, prefixed with `biz_`.
-    BusinessID
-}
+    BusinessID,
 
-paddle_id! {
     /// Unique Paddle ID for this payment method entity, prefixed with `paymtd_`.
-    PaymentMethodID
-}
+    PaymentMethodID,
 
-paddle_id! {
     /// Unique Paddle ID for this customer portal session entity, prefixed with `cpls_`.
-    CustomerPortalSessionID
-}
+    CustomerPortalSessionID,
 
-paddle_id! {
     /// Unique Paddle ID for this discount, prefixed with `dsc_`.
-    DiscountID
-}
+    DiscountID,
 
-paddle_id! {
     /// Unique code that customers can use to apply this discount at checkout. Use letters and numbers only, up to 16 characters. Not case-sensitive.
-    DiscountCode
-}
+    DiscountCode,
 
-paddle_id! {
     /// Unique Paddle ID for this event, prefixed with `evt_`.
-    EventID
-}
+    EventID,
 
-paddle_id! {
     /// Unique Paddle ID for this price, prefixed with `pri_`.
-    PriceID
-}
+    PriceID,
 
-paddle_id! {
     /// Unique Paddle ID for this product, prefixed with `pro_`.
-    ProductID
-}
+    ProductID,
 
-paddle_id! {
     /// Unique Paddle ID for API keys, prefixed with `apikey_`.
-    ApiKeyID
-}
+    ApiKeyID,
 
-paddle_id! {
     /// Unique Paddle ID for payouts, prefixed with `payout_`.
-    PayoutID
-}
+    PayoutID,
 
-paddle_id! {
     /// Unique Paddle ID for this notification, prefixed with `ntf_`.
-    NotificationID
-}
+    NotificationID,
 
-paddle_id! {
     /// Unique Paddle ID for this notification setting, prefixed with `ntfset_`.
-    NotificationSettingID
-}
+    NotificationSettingID,
 
-paddle_id! {
     /// Unique Paddle ID for this notification log, prefixed with `ntflog_`.
-    NotificationLogID
-}
+    NotificationLogID,
 
-paddle_id! {
     /// Webhook destination secret key, prefixed with `pdl_ntfset_`. Used for signature verification.
-    EndpointSecretKey
-}
+    EndpointSecretKey,
 
-paddle_id! {
     /// Just a Paddle ID. I've noticed this used in some places.
-    PaddleID
-}
+    PaddleID,
 
-paddle_id! {
     /// Unique Paddle ID for this simulation event, prefixed with `ntfsimevt_`.
-    SimulationEventID
-}
+    SimulationEventID,
 
-paddle_id! {
     /// Unique Paddle ID for this simulation run, prefixed with `ntfsimrun_`.
-    SimulationRunID
-}
+    SimulationRunID,
 
-paddle_id! {
     /// Unique Paddle ID for this simulation, prefixed with `ntfsim_`.
-    SimulationID
-}
+    SimulationID,
 
-paddle_id! {
     /// Paddle ID of the invoice that this transaction is related to, prefixed with `inv_`. Used for compatibility with the Paddle Invoice API, which is now deprecated. This field is scheduled to be removed in the next version of the Paddle API.
-    InvoiceId
+    InvoiceId,
 }


### PR DESCRIPTION
On more PR that derives `PartialEq`, `Eq`, `PartialOrd`, `Ord`, `Hash` for ids and enums.
For IDs added a macro that declares all structs and allows for an every ID to be created from a string (for integration and testing purposes).

cc @peterprototypes 