### PR TITLE
Converting all IDs to strings

### DIFF
--- a/src/ids.rs
+++ b/src/ids.rs
@@ -16,6 +16,12 @@ macro_rules! paddle_id {
             }
         }
 
+        impl Into<String> for $name {
+            fn into(self) -> String {
+                self.0
+            }
+        }
+
         impl AsRef<str> for $name {
             fn as_ref(&self) -> &str {
                 &self.0


### PR DESCRIPTION
Allows direct use of IDs in models across different ORMs.