### PR TITLE
String enum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,7 +1250,7 @@ dependencies = [
  "serde_qs",
  "serde_with",
  "sha2",
- "strum_macros",
+ "strum",
  "tokio",
  "url",
 ]
@@ -1750,6 +1750,15 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
 
 [[package]]
 name = "strum_macros"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -710,6 +710,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1244,6 +1250,7 @@ dependencies = [
  "serde_qs",
  "serde_with",
  "sha2",
+ "strum_macros",
  "tokio",
  "url",
 ]
@@ -1743,6 +1750,18 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "subtle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,6 @@ edition = "2021"
 [lib]
 doctest = false
 
-[features]
-default = ["strum"]
-
 [dependencies]
 reqwest = { version = "0.12", features = ["json"] }
 chrono = { version = "0.4", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ doctest = false
 
 [features]
 default = ["strum"]
-strum = ["strum_macros"]
 
 [dependencies]
 reqwest = { version = "0.12", features = ["json"] }
@@ -27,7 +26,7 @@ url = "2.5"
 serde_with = "3.12"
 sha2 = "0.10"
 hmac = { version = "0.12", features = ["std"] }
-strum_macros = { version = ">=0.26,<0.28", optional = true }
+strum = { version = ">=0.26,<0.28", features = ["derive"], optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,10 @@ edition = "2021"
 [lib]
 doctest = false
 
+[features]
+default = ["strum"]
+strum = ["strum_macros"]
+
 [dependencies]
 reqwest = { version = "0.12", features = ["json"] }
 chrono = { version = "0.4", features = ["serde"] }
@@ -23,6 +27,7 @@ url = "2.5"
 serde_with = "3.12"
 sha2 = "0.10"
 hmac = { version = "0.12", features = ["std"] }
+strum_macros = { version = ">=0.26,<0.28", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -4,7 +4,7 @@
 
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "strum")]
-use strum_macros::{Display, EnumString};
+use strum::{Display, EnumString};
 
 use crate::reports::ReportType;
 
@@ -476,7 +476,7 @@ pub enum CountryCodeSupported {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "kebab-case")]
-#[cfg_attr(feature = "strum", strum(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "strum", strum(serialize_all = "kebab-case"))]
 #[non_exhaustive]
 pub enum Status {
     /// Entity is active and can be used.
@@ -489,7 +489,7 @@ pub enum Status {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
-#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
 #[non_exhaustive]
 pub enum AdjustmentAction {
     /// Credits some or all the related transaction.
@@ -510,7 +510,7 @@ pub enum AdjustmentAction {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "lowercase")]
-#[cfg_attr(feature = "strum", strum(rename_all = "lowercase"))]
+#[cfg_attr(feature = "strum", strum(serialize_all = "lowercase"))]
 #[non_exhaustive]
 pub enum AdjustmentType {
     /// The grand total for the related transaction is adjusted.
@@ -596,7 +596,7 @@ pub enum CurrencyCode {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
-#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
 #[non_exhaustive]
 pub enum AdjustmentStatus {
     /// Adjustment is pending approval by Paddle. Most refunds for live accounts must be approved by Paddle.
@@ -664,7 +664,7 @@ pub enum CurrencyCodePayouts {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "lowercase")]
-#[cfg_attr(feature = "strum", strum(rename_all = "lowercase"))]
+#[cfg_attr(feature = "strum", strum(serialize_all = "lowercase"))]
 #[non_exhaustive]
 pub enum AdjustmentItemType {
     /// Full total for this transaction item is adjusted.
@@ -681,7 +681,7 @@ pub enum AdjustmentItemType {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "kebab-case")]
-#[cfg_attr(feature = "strum", strum(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "strum", strum(serialize_all = "kebab-case"))]
 #[non_exhaustive]
 pub enum Interval {
     Day,
@@ -694,7 +694,7 @@ pub enum Interval {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
-#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
 #[non_exhaustive]
 pub enum CardType {
     /// American Express
@@ -723,7 +723,7 @@ pub enum CardType {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "kebab-case")]
-#[cfg_attr(feature = "strum", strum(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "strum", strum(serialize_all = "kebab-case"))]
 #[non_exhaustive]
 pub enum CatalogType {
     /// Non-catalog item. Typically created for a specific transaction or subscription. Not returned when listing or shown in the Paddle dashboard.
@@ -736,7 +736,7 @@ pub enum CatalogType {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
-#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
 #[non_exhaustive]
 pub enum CollectionMode {
     /// Payment is collected automatically using a checkout initially, then using a payment method on file.
@@ -749,7 +749,7 @@ pub enum CollectionMode {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
-#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
 #[non_exhaustive]
 pub enum SavedPaymentMethodType {
     /// Alipay, popular in China.
@@ -768,7 +768,7 @@ pub enum SavedPaymentMethodType {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
-#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
 #[non_exhaustive]
 pub enum PaymentMethodOrigin {
     /// The customer chose to save this payment method while purchasing a one-time item.
@@ -781,7 +781,7 @@ pub enum PaymentMethodOrigin {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "kebab-case")]
-#[cfg_attr(feature = "strum", strum(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "strum", strum(serialize_all = "kebab-case"))]
 #[non_exhaustive]
 pub enum DiscountStatus {
     /// Entity is active and can be used.
@@ -794,7 +794,7 @@ pub enum DiscountStatus {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
-#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
 #[non_exhaustive]
 pub enum DiscountType {
     /// Discounts a checkout or transaction by a flat amount, for example -$100. Requires `currency_code`.
@@ -810,7 +810,7 @@ pub enum DiscountType {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
-#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
 #[non_exhaustive]
 pub enum EffectiveFrom {
     /// Takes effect on the next billing period.
@@ -834,7 +834,7 @@ pub enum Type {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
-#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
 #[non_exhaustive]
 pub enum ErrorCode {
     /// Cancellation not possible because the amount has already been canceled. Not typically returned for payments.
@@ -971,7 +971,6 @@ pub enum EventTypeName {
 /// Type of event sent by Paddle along with it's corresponding entity data
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(tag = "event_type", content = "data")]
 pub enum EventData {
     /// An [`address.created`](https://developer.paddle.com/webhooks/addresses/address-created) event.
@@ -1130,7 +1129,7 @@ pub enum EventData {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "lowercase")]
-#[cfg_attr(feature = "strum", strum(rename_all = "lowercase"))]
+#[cfg_attr(feature = "strum", strum(serialize_all = "lowercase"))]
 #[non_exhaustive]
 pub enum SubscriptionItemStatus {
     /// This item is active. It is not in trial and Paddle bills for it.
@@ -1145,7 +1144,7 @@ pub enum SubscriptionItemStatus {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
-#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
 #[non_exhaustive]
 pub enum TaxMode {
     /// Prices use the setting from your account.
@@ -1160,7 +1159,7 @@ pub enum TaxMode {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "kebab-case")]
-#[cfg_attr(feature = "strum", strum(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "strum", strum(serialize_all = "kebab-case"))]
 #[non_exhaustive]
 pub enum TaxCategory {
     /// Non-customizable digital files or media (not software) acquired with an up front payment that can be accessed without any physical product being delivered.
@@ -1203,7 +1202,7 @@ impl AsRef<str> for TaxCategory {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
-#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
 #[non_exhaustive]
 pub enum PaymentMethodType {
     /// Alipay, popular in China.
@@ -1282,7 +1281,7 @@ pub enum TrafficSource {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "lowercase")]
-#[cfg_attr(feature = "strum", strum(rename_all = "lowercase"))]
+#[cfg_attr(feature = "strum", strum(serialize_all = "lowercase"))]
 #[non_exhaustive]
 pub enum FilterOperator {
     /// Less than.
@@ -1294,7 +1293,7 @@ pub enum FilterOperator {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
-#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
 #[non_exhaustive]
 pub enum TransactionOrigin {
     /// Transaction created via the Paddle API.
@@ -1317,7 +1316,7 @@ pub enum TransactionOrigin {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
-#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
 #[non_exhaustive]
 pub enum ReportStatus {
     /// Report created, but Paddle is processing it. It's not yet ready for download.
@@ -1334,7 +1333,7 @@ pub enum ReportStatus {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
-#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
 #[non_exhaustive]
 pub enum AdjustmentsReportFilterName {
     /// Filter by adjustment action. Pass an array of strings containing any valid value for the `action` field against an adjustment.
@@ -1351,7 +1350,7 @@ pub enum AdjustmentsReportFilterName {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
-#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
 #[non_exhaustive]
 pub enum DiscountsReportFilterName {
     /// Filter by discount type. Pass an array of strings containing any valid value for the `type` field against a discount.
@@ -1366,7 +1365,7 @@ pub enum DiscountsReportFilterName {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
-#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
 #[non_exhaustive]
 pub enum BalanceReportFilterName {
     /// Filter by discount updated date. Pass an RFC 3339 datetime string.
@@ -1377,7 +1376,7 @@ pub enum BalanceReportFilterName {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
-#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
 #[non_exhaustive]
 pub enum ProductPricesReportFilterName {
     /// Filter by product status. Pass an array of strings containing any valid value for the `status` field against a product.
@@ -1398,7 +1397,7 @@ pub enum ProductPricesReportFilterName {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
-#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
 #[non_exhaustive]
 pub enum TransactionsReportFilterName {
     /// Filter by collection mode. Pass an array of strings containing any valid value for the `collection_mode` field against a transaction.
@@ -1417,7 +1416,7 @@ pub enum TransactionsReportFilterName {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
-#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
 #[non_exhaustive]
 pub enum AdjustmentsReportType {
     /// Adjustments reports contain information about refunds, credits, and chargebacks.
@@ -1434,7 +1433,7 @@ impl ReportType for AdjustmentsReportType {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
-#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
 #[non_exhaustive]
 pub enum TransactionsReportType {
     /// Transactions reports contain information about revenue received, past due invoices, draft and issued invoices, and canceled transactions.
@@ -1451,7 +1450,7 @@ impl ReportType for TransactionsReportType {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
-#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
 #[non_exhaustive]
 pub enum ProductsAndPricesReportType {
     /// Products and prices reports contain information about your products and prices. May include non-catalog products and prices.
@@ -1466,7 +1465,7 @@ impl ReportType for ProductsAndPricesReportType {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
-#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
 #[non_exhaustive]
 pub enum DiscountsReportType {
     /// Discounts reports contain information about your product and checkout discounts.
@@ -1481,7 +1480,7 @@ impl ReportType for DiscountsReportType {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
-#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
 #[non_exhaustive]
 pub enum BalanceReportType {
     /// Balance reports contain information about your account balance activity, including all movements of funds in and out of your balance.
@@ -1552,7 +1551,7 @@ pub enum SimulationKind {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
-#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
 #[non_exhaustive]
 pub enum PaymentAttemptStatus {
     /// Authorized but not captured. Payment attempt is incomplete.
@@ -1581,7 +1580,7 @@ pub enum PaymentAttemptStatus {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
-#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
 #[non_exhaustive]
 pub enum SubscriptionStatus {
     /// Subscription is active. Paddle is billing for this subscription and related transactions aren't past due.
@@ -1600,7 +1599,7 @@ pub enum SubscriptionStatus {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
-#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
 #[non_exhaustive]
 pub enum TransactionStatus {
     /// Transaction is missing required fields. Typically the first stage of a checkout before customer details are captured.
@@ -1623,7 +1622,7 @@ pub enum TransactionStatus {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "lowercase")]
-#[cfg_attr(feature = "strum", strum(rename_all = "lowercase"))]
+#[cfg_attr(feature = "strum", strum(serialize_all = "lowercase"))]
 #[non_exhaustive]
 pub enum ScheduledChangeAction {
     /// Subscription is scheduled to cancel. Its status changes to `canceled` on the `effective_at` date.
@@ -1638,7 +1637,7 @@ pub enum ScheduledChangeAction {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
-#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
 #[non_exhaustive]
 pub enum SubscriptionOnPaymentFailure {
     /// In case of payment failure, prevent the change to the subscription from applying.
@@ -1651,7 +1650,7 @@ pub enum SubscriptionOnPaymentFailure {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "lowercase")]
-#[cfg_attr(feature = "strum", strum(rename_all = "lowercase"))]
+#[cfg_attr(feature = "strum", strum(serialize_all = "lowercase"))]
 #[non_exhaustive]
 pub enum UpdateSummaryResultAction {
     /// Changes to the subscription results in a prorated credit.
@@ -1668,7 +1667,7 @@ pub enum UpdateSummaryResultAction {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
-#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
 #[non_exhaustive]
 pub enum ProrationBillingMode {
     /// Paddle calculates the prorated amount for the subscription changes based on the current billing cycle, then
@@ -1691,7 +1690,7 @@ pub enum ProrationBillingMode {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
-#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
 #[non_exhaustive]
 pub enum SubscriptionOnResume {
     /// When resuming, continue the existing billing period. If the customer resumes before the end date of the existing billing period, there's no immediate charge. If after, an error is returned.
@@ -1704,7 +1703,7 @@ pub enum SubscriptionOnResume {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "lowercase")]
-#[cfg_attr(feature = "strum", strum(rename_all = "lowercase"))]
+#[cfg_attr(feature = "strum", strum(serialize_all = "lowercase"))]
 #[non_exhaustive]
 pub enum Disposition {
     /// Generated URL downloads the PDF as an attachment. Browsers typically automatically save the PDF.
@@ -1716,7 +1715,7 @@ pub enum Disposition {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "lowercase")]
-#[cfg_attr(feature = "strum", strum(rename_all = "lowercase"))]
+#[cfg_attr(feature = "strum", strum(serialize_all = "lowercase"))]
 #[non_exhaustive]
 pub enum PayoutStatus {
     /// Payout is paid.
@@ -1728,7 +1727,7 @@ pub enum PayoutStatus {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "lowercase")]
-#[cfg_attr(feature = "strum", strum(rename_all = "lowercase"))]
+#[cfg_attr(feature = "strum", strum(serialize_all = "lowercase"))]
 #[non_exhaustive]
 pub enum ApiKeyStatus {
     Active,
@@ -1740,7 +1739,7 @@ pub enum ApiKeyStatus {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
-#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
 #[non_exhaustive]
 pub enum SubscriptionInclude {
     /// Include an object with a preview of the next transaction for this subscription. May include prorated charges that aren't yet billed and one-time charges.

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -8,7 +8,7 @@ use strum::{Display, EnumString};
 
 use crate::reports::ReportType;
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 pub enum CountryCodeSupported {
@@ -473,7 +473,7 @@ pub enum CountryCodeSupported {
 }
 
 /// Whether this entity can be used in Paddle.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "kebab-case")]
 #[cfg_attr(feature = "strum", strum(serialize_all = "kebab-case"))]
@@ -486,7 +486,7 @@ pub enum Status {
 }
 
 /// How this adjustment impacts the related transaction.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
@@ -507,7 +507,7 @@ pub enum AdjustmentAction {
 }
 
 /// Type of adjustment. Use `full` to adjust the grand total for the related transaction. Include an `items` array when creating a `partial` adjustment. If omitted, defaults to `partial`.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "lowercase")]
 #[cfg_attr(feature = "strum", strum(serialize_all = "lowercase"))]
@@ -520,7 +520,7 @@ pub enum AdjustmentType {
 }
 
 /// Supported three-letter ISO 4217 currency code.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 pub enum CurrencyCode {
@@ -593,7 +593,7 @@ pub enum CurrencyCode {
 /// Most refunds for live accounts are created with the status of `pending_approval` until reviewed by Paddle, but some are automatically approved. For sandbox accounts, Paddle automatically approves refunds every ten minutes.
 ///
 /// Credit adjustments don't require approval from Paddle, so they're created as `approved`.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
@@ -610,7 +610,7 @@ pub enum AdjustmentStatus {
 }
 
 /// Three-letter ISO 4217 currency code for chargeback fees.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 pub enum CurrencyCodeChargebacks {
@@ -627,7 +627,7 @@ pub enum CurrencyCodeChargebacks {
 }
 
 /// Supported three-letter ISO 4217 currency code for payouts from Paddle.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 pub enum CurrencyCodePayouts {
@@ -661,7 +661,7 @@ pub enum CurrencyCodePayouts {
 
 /// Type of adjustment for this transaction item. `tax` adjustments are automatically created by Paddle.
 /// Include `amount` when creating a `partial` adjustment.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "lowercase")]
 #[cfg_attr(feature = "strum", strum(serialize_all = "lowercase"))]
@@ -678,7 +678,7 @@ pub enum AdjustmentItemType {
 }
 
 /// Unit of time.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "kebab-case")]
 #[cfg_attr(feature = "strum", strum(serialize_all = "kebab-case"))]
@@ -691,7 +691,7 @@ pub enum Interval {
 }
 
 /// Type of credit or debit card used to pay.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
@@ -720,7 +720,7 @@ pub enum CardType {
 }
 
 /// Type of item. Standard items are considered part of your catalog and are shown on the Paddle dashboard.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "kebab-case")]
 #[cfg_attr(feature = "strum", strum(serialize_all = "kebab-case"))]
@@ -733,7 +733,7 @@ pub enum CatalogType {
 }
 
 /// How payment is collected. `automatic` for checkout, `manual` for invoices.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
@@ -746,7 +746,7 @@ pub enum CollectionMode {
 }
 
 /// Type of payment method saved.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
@@ -765,7 +765,7 @@ pub enum SavedPaymentMethodType {
 }
 
 /// Describes how this payment method was saved.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
@@ -778,7 +778,7 @@ pub enum PaymentMethodOrigin {
 }
 
 /// Whether this entity can be used in Paddle.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "kebab-case")]
 #[cfg_attr(feature = "strum", strum(serialize_all = "kebab-case"))]
@@ -791,7 +791,7 @@ pub enum DiscountStatus {
 }
 
 /// Type of discount. Determines how this discount impacts the checkout or transaction total.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
@@ -807,7 +807,7 @@ pub enum DiscountType {
 
 /// When this subscription change should take effect from. Defaults to `next_billing_period`, which creates a
 /// `scheduled_change` to apply the subscription change at the end of the billing period.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
@@ -820,7 +820,7 @@ pub enum EffectiveFrom {
 }
 
 /// Type of error encountered.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 pub enum Type {
@@ -831,7 +831,7 @@ pub enum Type {
 }
 
 /// Reason why a payment attempt failed. Returns `null` if payment captured successfully.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
@@ -878,7 +878,7 @@ pub enum ErrorCode {
 }
 
 /// Type of event sent by Paddle, in the format `entity.event_type`.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 pub enum EventTypeName {
@@ -1126,7 +1126,7 @@ pub enum EventData {
 }
 
 /// Status of this subscription item. Set automatically by Paddle.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "lowercase")]
 #[cfg_attr(feature = "strum", strum(serialize_all = "lowercase"))]
@@ -1141,7 +1141,7 @@ pub enum SubscriptionItemStatus {
 }
 
 /// How tax is calculated for this price.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
@@ -1156,7 +1156,7 @@ pub enum TaxMode {
 }
 
 /// Tax category for this product. Used for charging the correct rate of tax. Selected tax category must be enabled on your Paddle account.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "kebab-case")]
 #[cfg_attr(feature = "strum", strum(serialize_all = "kebab-case"))]
@@ -1199,7 +1199,7 @@ impl AsRef<str> for TaxCategory {
 }
 
 /// Type of payment method used for this payment attempt.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
@@ -1228,7 +1228,7 @@ pub enum PaymentMethodType {
 }
 
 /// Status of this notification.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 pub enum NotificationStatus {
@@ -1243,7 +1243,7 @@ pub enum NotificationStatus {
 }
 
 /// Describes how this notification was created.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 pub enum NotificationOrigin {
@@ -1254,7 +1254,7 @@ pub enum NotificationOrigin {
 }
 
 /// Where notifications should be sent for this destination.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 pub enum NotificationSettingType {
@@ -1265,7 +1265,7 @@ pub enum NotificationSettingType {
 }
 
 /// Whether Paddle should deliver real platform events, simulation events or both to this notification destination.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 pub enum TrafficSource {
@@ -1278,7 +1278,7 @@ pub enum TrafficSource {
 }
 
 /// Operator to use when filtering.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "lowercase")]
 #[cfg_attr(feature = "strum", strum(serialize_all = "lowercase"))]
@@ -1290,7 +1290,7 @@ pub enum FilterOperator {
     Gte,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
@@ -1313,7 +1313,7 @@ pub enum TransactionOrigin {
 /// Status of this report. Set automatically by Paddle.
 ///
 /// Reports are created as `pending` initially, then move to `ready` when they're available to download.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
@@ -1330,7 +1330,7 @@ pub enum ReportStatus {
 }
 
 /// Field name to filter by.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
@@ -1347,7 +1347,7 @@ pub enum AdjustmentsReportFilterName {
 }
 
 /// Field name to filter by.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
@@ -1362,7 +1362,7 @@ pub enum DiscountsReportFilterName {
 }
 
 /// Field name to filter by.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
@@ -1373,7 +1373,7 @@ pub enum BalanceReportFilterName {
 }
 
 /// Field name to filter by.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
@@ -1394,7 +1394,7 @@ pub enum ProductPricesReportFilterName {
 }
 
 /// Field name to filter by.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
@@ -1413,7 +1413,7 @@ pub enum TransactionsReportFilterName {
 }
 
 /// Type of report.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
@@ -1430,7 +1430,7 @@ impl ReportType for AdjustmentsReportType {
 }
 
 /// Type of report.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
@@ -1447,7 +1447,7 @@ impl ReportType for TransactionsReportType {
 }
 
 /// Type of report.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
@@ -1462,7 +1462,7 @@ impl ReportType for ProductsAndPricesReportType {
 }
 
 /// Type of report.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
@@ -1477,7 +1477,7 @@ impl ReportType for DiscountsReportType {
 }
 
 /// Type of report.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
@@ -1492,7 +1492,7 @@ impl ReportType for BalanceReportType {
 }
 
 /// Status of this simulation run log.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 pub enum SimulationEventStatus {
@@ -1507,7 +1507,7 @@ pub enum SimulationEventStatus {
 }
 
 /// Status of this simulation run.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 pub enum SimulationRunStatus {
@@ -1520,7 +1520,7 @@ pub enum SimulationRunStatus {
 }
 
 /// Scenario for a simulation.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 pub enum SimulationScenarioType {
@@ -1537,7 +1537,7 @@ pub enum SimulationScenarioType {
 }
 
 /// Type of simulation.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 pub enum SimulationKind {
@@ -1548,7 +1548,7 @@ pub enum SimulationKind {
 }
 
 /// Status of this payment attempt.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
@@ -1577,7 +1577,7 @@ pub enum PaymentAttemptStatus {
 }
 
 /// Status of this subscription. Set automatically by Paddle. Use the pause subscription or cancel subscription operations to change.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
@@ -1596,7 +1596,7 @@ pub enum SubscriptionStatus {
 }
 
 /// Status of this transaction. You may set a transaction to `billed` or `canceled`, other statuses are set automatically by Paddle. Automatically-collected transactions may return `completed` if payment is captured successfully, or `past_due` if payment failed.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
@@ -1619,7 +1619,7 @@ pub enum TransactionStatus {
 }
 
 /// Kind of change that's scheduled to be applied to this subscription.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "lowercase")]
 #[cfg_attr(feature = "strum", strum(serialize_all = "lowercase"))]
@@ -1634,7 +1634,7 @@ pub enum ScheduledChangeAction {
 }
 
 /// How Paddle should handle changes made to a subscription or its items if the payment fails during update. If omitted, defaults to `prevent_change`.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
@@ -1647,7 +1647,7 @@ pub enum SubscriptionOnPaymentFailure {
 }
 
 /// Whether the subscription change results in a prorated credit or a charge.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "lowercase")]
 #[cfg_attr(feature = "strum", strum(serialize_all = "lowercase"))]
@@ -1664,7 +1664,7 @@ pub enum UpdateSummaryResultAction {
 ///
 /// For automatically-collected subscriptions, responses may take longer than usual if a proration billing mode that
 /// collects for payment immediately is used.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
@@ -1687,7 +1687,7 @@ pub enum ProrationBillingMode {
 }
 
 /// How Paddle should set the billing period for the subscription when resuming. If omitted, defaults to `start_new_billing_period`.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]
@@ -1700,7 +1700,7 @@ pub enum SubscriptionOnResume {
 }
 
 /// Determine whether the generated URL should download the PDF as an attachment saved locally, or open it inline in the browser.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "lowercase")]
 #[cfg_attr(feature = "strum", strum(serialize_all = "lowercase"))]
@@ -1712,7 +1712,7 @@ pub enum Disposition {
     Inline,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "lowercase")]
 #[cfg_attr(feature = "strum", strum(serialize_all = "lowercase"))]
@@ -1724,7 +1724,7 @@ pub enum PayoutStatus {
     Unpaid,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "lowercase")]
 #[cfg_attr(feature = "strum", strum(serialize_all = "lowercase"))]
@@ -1736,7 +1736,7 @@ pub enum ApiKeyStatus {
 }
 
 /// Include related entities in the response.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(serialize_all = "snake_case"))]

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -475,9 +475,9 @@ pub enum CountryCodeSupported {
 /// Whether this entity can be used in Paddle.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
-#[non_exhaustive]
 #[serde(rename_all = "kebab-case")]
 #[cfg_attr(feature = "strum", strum(rename_all = "kebab-case"))]
+#[non_exhaustive]
 pub enum Status {
     /// Entity is active and can be used.
     Active,
@@ -488,9 +488,9 @@ pub enum Status {
 /// How this adjustment impacts the related transaction.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
-#[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[non_exhaustive]
 pub enum AdjustmentAction {
     /// Credits some or all the related transaction.
     Credit,
@@ -509,9 +509,9 @@ pub enum AdjustmentAction {
 /// Type of adjustment. Use `full` to adjust the grand total for the related transaction. Include an `items` array when creating a `partial` adjustment. If omitted, defaults to `partial`.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
-#[non_exhaustive]
 #[serde(rename_all = "lowercase")]
 #[cfg_attr(feature = "strum", strum(rename_all = "lowercase"))]
+#[non_exhaustive]
 pub enum AdjustmentType {
     /// The grand total for the related transaction is adjusted.
     Full,
@@ -595,9 +595,9 @@ pub enum CurrencyCode {
 /// Credit adjustments don't require approval from Paddle, so they're created as `approved`.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
-#[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[non_exhaustive]
 pub enum AdjustmentStatus {
     /// Adjustment is pending approval by Paddle. Most refunds for live accounts must be approved by Paddle.
     PendingApproval,
@@ -663,9 +663,9 @@ pub enum CurrencyCodePayouts {
 /// Include `amount` when creating a `partial` adjustment.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
-#[non_exhaustive]
 #[serde(rename_all = "lowercase")]
 #[cfg_attr(feature = "strum", strum(rename_all = "lowercase"))]
+#[non_exhaustive]
 pub enum AdjustmentItemType {
     /// Full total for this transaction item is adjusted.
     Full,
@@ -680,9 +680,9 @@ pub enum AdjustmentItemType {
 /// Unit of time.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
-#[non_exhaustive]
 #[serde(rename_all = "kebab-case")]
 #[cfg_attr(feature = "strum", strum(rename_all = "kebab-case"))]
+#[non_exhaustive]
 pub enum Interval {
     Day,
     Week,
@@ -693,9 +693,9 @@ pub enum Interval {
 /// Type of credit or debit card used to pay.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
-#[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[non_exhaustive]
 pub enum CardType {
     /// American Express
     AmericanExpress,
@@ -722,9 +722,9 @@ pub enum CardType {
 /// Type of item. Standard items are considered part of your catalog and are shown on the Paddle dashboard.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
-#[non_exhaustive]
 #[serde(rename_all = "kebab-case")]
 #[cfg_attr(feature = "strum", strum(rename_all = "kebab-case"))]
+#[non_exhaustive]
 pub enum CatalogType {
     /// Non-catalog item. Typically created for a specific transaction or subscription. Not returned when listing or shown in the Paddle dashboard.
     Custom,
@@ -735,9 +735,9 @@ pub enum CatalogType {
 /// How payment is collected. `automatic` for checkout, `manual` for invoices.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
-#[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[non_exhaustive]
 pub enum CollectionMode {
     /// Payment is collected automatically using a checkout initially, then using a payment method on file.
     Automatic,
@@ -748,9 +748,9 @@ pub enum CollectionMode {
 /// Type of payment method saved.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
-#[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[non_exhaustive]
 pub enum SavedPaymentMethodType {
     /// Alipay, popular in China.
     Alipay,
@@ -767,9 +767,9 @@ pub enum SavedPaymentMethodType {
 /// Describes how this payment method was saved.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
-#[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[non_exhaustive]
 pub enum PaymentMethodOrigin {
     /// The customer chose to save this payment method while purchasing a one-time item.
     SavedDuringPurchase,
@@ -780,9 +780,9 @@ pub enum PaymentMethodOrigin {
 /// Whether this entity can be used in Paddle.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
-#[non_exhaustive]
 #[serde(rename_all = "kebab-case")]
 #[cfg_attr(feature = "strum", strum(rename_all = "kebab-case"))]
+#[non_exhaustive]
 pub enum DiscountStatus {
     /// Entity is active and can be used.
     Active,
@@ -793,9 +793,9 @@ pub enum DiscountStatus {
 /// Type of discount. Determines how this discount impacts the checkout or transaction total.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
-#[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[non_exhaustive]
 pub enum DiscountType {
     /// Discounts a checkout or transaction by a flat amount, for example -$100. Requires `currency_code`.
     Flat,
@@ -809,9 +809,9 @@ pub enum DiscountType {
 /// `scheduled_change` to apply the subscription change at the end of the billing period.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
-#[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[non_exhaustive]
 pub enum EffectiveFrom {
     /// Takes effect on the next billing period.
     NextBillingPeriod,
@@ -833,9 +833,9 @@ pub enum Type {
 /// Reason why a payment attempt failed. Returns `null` if payment captured successfully.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
-#[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[non_exhaustive]
 pub enum ErrorCode {
     /// Cancellation not possible because the amount has already been canceled. Not typically returned for payments.
     AlreadyCanceled,
@@ -1129,9 +1129,9 @@ pub enum EventData {
 /// Status of this subscription item. Set automatically by Paddle.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
-#[non_exhaustive]
 #[serde(rename_all = "lowercase")]
 #[cfg_attr(feature = "strum", strum(rename_all = "lowercase"))]
+#[non_exhaustive]
 pub enum SubscriptionItemStatus {
     /// This item is active. It is not in trial and Paddle bills for it.
     Active,
@@ -1144,9 +1144,9 @@ pub enum SubscriptionItemStatus {
 /// How tax is calculated for this price.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
-#[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[non_exhaustive]
 pub enum TaxMode {
     /// Prices use the setting from your account.
     AccountSetting,
@@ -1159,9 +1159,9 @@ pub enum TaxMode {
 /// Tax category for this product. Used for charging the correct rate of tax. Selected tax category must be enabled on your Paddle account.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
-#[non_exhaustive]
 #[serde(rename_all = "kebab-case")]
 #[cfg_attr(feature = "strum", strum(rename_all = "kebab-case"))]
+#[non_exhaustive]
 pub enum TaxCategory {
     /// Non-customizable digital files or media (not software) acquired with an up front payment that can be accessed without any physical product being delivered.
     DigitalGoods,
@@ -1202,9 +1202,9 @@ impl AsRef<str> for TaxCategory {
 /// Type of payment method used for this payment attempt.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
-#[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[non_exhaustive]
 pub enum PaymentMethodType {
     /// Alipay, popular in China.
     Alipay,
@@ -1281,9 +1281,9 @@ pub enum TrafficSource {
 /// Operator to use when filtering.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
-#[non_exhaustive]
 #[serde(rename_all = "lowercase")]
 #[cfg_attr(feature = "strum", strum(rename_all = "lowercase"))]
+#[non_exhaustive]
 pub enum FilterOperator {
     /// Less than.
     Lt,
@@ -1293,9 +1293,9 @@ pub enum FilterOperator {
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
-#[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[non_exhaustive]
 pub enum TransactionOrigin {
     /// Transaction created via the Paddle API.
     Api,
@@ -1316,9 +1316,9 @@ pub enum TransactionOrigin {
 /// Reports are created as `pending` initially, then move to `ready` when they're available to download.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
-#[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[non_exhaustive]
 pub enum ReportStatus {
     /// Report created, but Paddle is processing it. It's not yet ready for download.
     Pending,
@@ -1333,9 +1333,9 @@ pub enum ReportStatus {
 /// Field name to filter by.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
-#[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[non_exhaustive]
 pub enum AdjustmentsReportFilterName {
     /// Filter by adjustment action. Pass an array of strings containing any valid value for the `action` field against an adjustment.
     Action,
@@ -1350,9 +1350,9 @@ pub enum AdjustmentsReportFilterName {
 /// Field name to filter by.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
-#[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[non_exhaustive]
 pub enum DiscountsReportFilterName {
     /// Filter by discount type. Pass an array of strings containing any valid value for the `type` field against a discount.
     Type,
@@ -1365,9 +1365,9 @@ pub enum DiscountsReportFilterName {
 /// Field name to filter by.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
-#[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[non_exhaustive]
 pub enum BalanceReportFilterName {
     /// Filter by discount updated date. Pass an RFC 3339 datetime string.
     UpdatedAt,
@@ -1376,9 +1376,9 @@ pub enum BalanceReportFilterName {
 /// Field name to filter by.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
-#[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[non_exhaustive]
 pub enum ProductPricesReportFilterName {
     /// Filter by product status. Pass an array of strings containing any valid value for the `status` field against a product.
     ProductStatus,
@@ -1397,9 +1397,9 @@ pub enum ProductPricesReportFilterName {
 /// Field name to filter by.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
-#[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[non_exhaustive]
 pub enum TransactionsReportFilterName {
     /// Filter by collection mode. Pass an array of strings containing any valid value for the `collection_mode` field against a transaction.
     CollectionMode,
@@ -1416,9 +1416,9 @@ pub enum TransactionsReportFilterName {
 /// Type of report.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
-#[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[non_exhaustive]
 pub enum AdjustmentsReportType {
     /// Adjustments reports contain information about refunds, credits, and chargebacks.
     Adjustments,
@@ -1433,9 +1433,9 @@ impl ReportType for AdjustmentsReportType {
 /// Type of report.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
-#[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[non_exhaustive]
 pub enum TransactionsReportType {
     /// Transactions reports contain information about revenue received, past due invoices, draft and issued invoices, and canceled transactions.
     Transactions,
@@ -1450,9 +1450,9 @@ impl ReportType for TransactionsReportType {
 /// Type of report.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
-#[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[non_exhaustive]
 pub enum ProductsAndPricesReportType {
     /// Products and prices reports contain information about your products and prices. May include non-catalog products and prices.
     ProductsPrices,
@@ -1465,9 +1465,9 @@ impl ReportType for ProductsAndPricesReportType {
 /// Type of report.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
-#[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[non_exhaustive]
 pub enum DiscountsReportType {
     /// Discounts reports contain information about your product and checkout discounts.
     Discounts,
@@ -1480,9 +1480,9 @@ impl ReportType for DiscountsReportType {
 /// Type of report.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
-#[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[non_exhaustive]
 pub enum BalanceReportType {
     /// Balance reports contain information about your account balance activity, including all movements of funds in and out of your balance.
     Balance,
@@ -1551,9 +1551,9 @@ pub enum SimulationKind {
 /// Status of this payment attempt.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
-#[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[non_exhaustive]
 pub enum PaymentAttemptStatus {
     /// Authorized but not captured. Payment attempt is incomplete.
     Authorized,
@@ -1580,9 +1580,9 @@ pub enum PaymentAttemptStatus {
 /// Status of this subscription. Set automatically by Paddle. Use the pause subscription or cancel subscription operations to change.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
-#[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[non_exhaustive]
 pub enum SubscriptionStatus {
     /// Subscription is active. Paddle is billing for this subscription and related transactions aren't past due.
     Active,
@@ -1599,9 +1599,9 @@ pub enum SubscriptionStatus {
 /// Status of this transaction. You may set a transaction to `billed` or `canceled`, other statuses are set automatically by Paddle. Automatically-collected transactions may return `completed` if payment is captured successfully, or `past_due` if payment failed.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
-#[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[non_exhaustive]
 pub enum TransactionStatus {
     /// Transaction is missing required fields. Typically the first stage of a checkout before customer details are captured.
     Draft,
@@ -1622,9 +1622,9 @@ pub enum TransactionStatus {
 /// Kind of change that's scheduled to be applied to this subscription.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
-#[non_exhaustive]
 #[serde(rename_all = "lowercase")]
 #[cfg_attr(feature = "strum", strum(rename_all = "lowercase"))]
+#[non_exhaustive]
 pub enum ScheduledChangeAction {
     /// Subscription is scheduled to cancel. Its status changes to `canceled` on the `effective_at` date.
     Cancel,
@@ -1637,9 +1637,9 @@ pub enum ScheduledChangeAction {
 /// How Paddle should handle changes made to a subscription or its items if the payment fails during update. If omitted, defaults to `prevent_change`.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
-#[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[non_exhaustive]
 pub enum SubscriptionOnPaymentFailure {
     /// In case of payment failure, prevent the change to the subscription from applying.
     PreventChange,
@@ -1650,9 +1650,9 @@ pub enum SubscriptionOnPaymentFailure {
 /// Whether the subscription change results in a prorated credit or a charge.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
-#[non_exhaustive]
 #[serde(rename_all = "lowercase")]
 #[cfg_attr(feature = "strum", strum(rename_all = "lowercase"))]
+#[non_exhaustive]
 pub enum UpdateSummaryResultAction {
     /// Changes to the subscription results in a prorated credit.
     Credit,
@@ -1667,9 +1667,9 @@ pub enum UpdateSummaryResultAction {
 /// collects for payment immediately is used.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
-#[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[non_exhaustive]
 pub enum ProrationBillingMode {
     /// Paddle calculates the prorated amount for the subscription changes based on the current billing cycle, then
     /// creates a transaction to collect immediately.
@@ -1690,9 +1690,9 @@ pub enum ProrationBillingMode {
 /// How Paddle should set the billing period for the subscription when resuming. If omitted, defaults to `start_new_billing_period`.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
-#[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
+#[non_exhaustive]
 pub enum SubscriptionOnResume {
     /// When resuming, continue the existing billing period. If the customer resumes before the end date of the existing billing period, there's no immediate charge. If after, an error is returned.
     ContinueExistingBillingPeriod,
@@ -1703,9 +1703,9 @@ pub enum SubscriptionOnResume {
 /// Determine whether the generated URL should download the PDF as an attachment saved locally, or open it inline in the browser.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
-#[non_exhaustive]
 #[serde(rename_all = "lowercase")]
 #[cfg_attr(feature = "strum", strum(rename_all = "lowercase"))]
+#[non_exhaustive]
 pub enum Disposition {
     /// Generated URL downloads the PDF as an attachment. Browsers typically automatically save the PDF.
     Attachment,
@@ -1715,9 +1715,9 @@ pub enum Disposition {
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
-#[non_exhaustive]
 #[serde(rename_all = "lowercase")]
 #[cfg_attr(feature = "strum", strum(rename_all = "lowercase"))]
+#[non_exhaustive]
 pub enum PayoutStatus {
     /// Payout is paid.
     Paid,
@@ -1727,9 +1727,9 @@ pub enum PayoutStatus {
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "strum", derive(EnumString, Display))]
-#[non_exhaustive]
 #[serde(rename_all = "lowercase")]
 #[cfg_attr(feature = "strum", strum(rename_all = "lowercase"))]
+#[non_exhaustive]
 pub enum ApiKeyStatus {
     Active,
     Expired,

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -3,10 +3,13 @@
 #![allow(clippy::upper_case_acronyms, clippy::enum_variant_names)]
 
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "strum")]
+use strum_macros::{Display, EnumString};
 
 use crate::reports::ReportType;
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 pub enum CountryCodeSupported {
     /// Andorra
@@ -471,8 +474,10 @@ pub enum CountryCodeSupported {
 
 /// Whether this entity can be used in Paddle.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 #[serde(rename_all = "kebab-case")]
+#[cfg_attr(feature = "strum", strum(rename_all = "kebab-case"))]
 pub enum Status {
     /// Entity is active and can be used.
     Active,
@@ -482,8 +487,10 @@ pub enum Status {
 
 /// How this adjustment impacts the related transaction.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
 pub enum AdjustmentAction {
     /// Credits some or all the related transaction.
     Credit,
@@ -501,8 +508,10 @@ pub enum AdjustmentAction {
 
 /// Type of adjustment. Use `full` to adjust the grand total for the related transaction. Include an `items` array when creating a `partial` adjustment. If omitted, defaults to `partial`.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 #[serde(rename_all = "lowercase")]
+#[cfg_attr(feature = "strum", strum(rename_all = "lowercase"))]
 pub enum AdjustmentType {
     /// The grand total for the related transaction is adjusted.
     Full,
@@ -512,6 +521,7 @@ pub enum AdjustmentType {
 
 /// Supported three-letter ISO 4217 currency code.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 pub enum CurrencyCode {
     /// United States Dollar
@@ -584,8 +594,10 @@ pub enum CurrencyCode {
 ///
 /// Credit adjustments don't require approval from Paddle, so they're created as `approved`.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
 pub enum AdjustmentStatus {
     /// Adjustment is pending approval by Paddle. Most refunds for live accounts must be approved by Paddle.
     PendingApproval,
@@ -599,6 +611,7 @@ pub enum AdjustmentStatus {
 
 /// Three-letter ISO 4217 currency code for chargeback fees.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 pub enum CurrencyCodeChargebacks {
     /// Australian Dollar
@@ -615,6 +628,7 @@ pub enum CurrencyCodeChargebacks {
 
 /// Supported three-letter ISO 4217 currency code for payouts from Paddle.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 pub enum CurrencyCodePayouts {
     /// Australian Dollar
@@ -648,8 +662,10 @@ pub enum CurrencyCodePayouts {
 /// Type of adjustment for this transaction item. `tax` adjustments are automatically created by Paddle.
 /// Include `amount` when creating a `partial` adjustment.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 #[serde(rename_all = "lowercase")]
+#[cfg_attr(feature = "strum", strum(rename_all = "lowercase"))]
 pub enum AdjustmentItemType {
     /// Full total for this transaction item is adjusted.
     Full,
@@ -663,8 +679,10 @@ pub enum AdjustmentItemType {
 
 /// Unit of time.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 #[serde(rename_all = "kebab-case")]
+#[cfg_attr(feature = "strum", strum(rename_all = "kebab-case"))]
 pub enum Interval {
     Day,
     Week,
@@ -674,8 +692,10 @@ pub enum Interval {
 
 /// Type of credit or debit card used to pay.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
 pub enum CardType {
     /// American Express
     AmericanExpress,
@@ -701,8 +721,10 @@ pub enum CardType {
 
 /// Type of item. Standard items are considered part of your catalog and are shown on the Paddle dashboard.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 #[serde(rename_all = "kebab-case")]
+#[cfg_attr(feature = "strum", strum(rename_all = "kebab-case"))]
 pub enum CatalogType {
     /// Non-catalog item. Typically created for a specific transaction or subscription. Not returned when listing or shown in the Paddle dashboard.
     Custom,
@@ -712,8 +734,10 @@ pub enum CatalogType {
 
 /// How payment is collected. `automatic` for checkout, `manual` for invoices.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
 pub enum CollectionMode {
     /// Payment is collected automatically using a checkout initially, then using a payment method on file.
     Automatic,
@@ -723,8 +747,10 @@ pub enum CollectionMode {
 
 /// Type of payment method saved.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
 pub enum SavedPaymentMethodType {
     /// Alipay, popular in China.
     Alipay,
@@ -740,8 +766,10 @@ pub enum SavedPaymentMethodType {
 
 /// Describes how this payment method was saved.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
 pub enum PaymentMethodOrigin {
     /// The customer chose to save this payment method while purchasing a one-time item.
     SavedDuringPurchase,
@@ -751,8 +779,10 @@ pub enum PaymentMethodOrigin {
 
 /// Whether this entity can be used in Paddle.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 #[serde(rename_all = "kebab-case")]
+#[cfg_attr(feature = "strum", strum(rename_all = "kebab-case"))]
 pub enum DiscountStatus {
     /// Entity is active and can be used.
     Active,
@@ -762,8 +792,10 @@ pub enum DiscountStatus {
 
 /// Type of discount. Determines how this discount impacts the checkout or transaction total.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
 pub enum DiscountType {
     /// Discounts a checkout or transaction by a flat amount, for example -$100. Requires `currency_code`.
     Flat,
@@ -776,8 +808,10 @@ pub enum DiscountType {
 /// When this subscription change should take effect from. Defaults to `next_billing_period`, which creates a
 /// `scheduled_change` to apply the subscription change at the end of the billing period.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
 pub enum EffectiveFrom {
     /// Takes effect on the next billing period.
     NextBillingPeriod,
@@ -787,6 +821,7 @@ pub enum EffectiveFrom {
 
 /// Type of error encountered.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 pub enum Type {
     /// Typically means there's a problem with the request that you made.
@@ -797,8 +832,10 @@ pub enum Type {
 
 /// Reason why a payment attempt failed. Returns `null` if payment captured successfully.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
 pub enum ErrorCode {
     /// Cancellation not possible because the amount has already been canceled. Not typically returned for payments.
     AlreadyCanceled,
@@ -842,6 +879,7 @@ pub enum ErrorCode {
 
 /// Type of event sent by Paddle, in the format `entity.event_type`.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 pub enum EventTypeName {
     /// An [`address.created`](https://developer.paddle.com/webhooks/addresses/address-created) event.
@@ -933,6 +971,7 @@ pub enum EventTypeName {
 /// Type of event sent by Paddle along with it's corresponding entity data
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(tag = "event_type", content = "data")]
 pub enum EventData {
     /// An [`address.created`](https://developer.paddle.com/webhooks/addresses/address-created) event.
@@ -1089,8 +1128,10 @@ pub enum EventData {
 
 /// Status of this subscription item. Set automatically by Paddle.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 #[serde(rename_all = "lowercase")]
+#[cfg_attr(feature = "strum", strum(rename_all = "lowercase"))]
 pub enum SubscriptionItemStatus {
     /// This item is active. It is not in trial and Paddle bills for it.
     Active,
@@ -1102,8 +1143,10 @@ pub enum SubscriptionItemStatus {
 
 /// How tax is calculated for this price.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
 pub enum TaxMode {
     /// Prices use the setting from your account.
     AccountSetting,
@@ -1115,8 +1158,10 @@ pub enum TaxMode {
 
 /// Tax category for this product. Used for charging the correct rate of tax. Selected tax category must be enabled on your Paddle account.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 #[serde(rename_all = "kebab-case")]
+#[cfg_attr(feature = "strum", strum(rename_all = "kebab-case"))]
 pub enum TaxCategory {
     /// Non-customizable digital files or media (not software) acquired with an up front payment that can be accessed without any physical product being delivered.
     DigitalGoods,
@@ -1156,8 +1201,10 @@ impl AsRef<str> for TaxCategory {
 
 /// Type of payment method used for this payment attempt.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
 pub enum PaymentMethodType {
     /// Alipay, popular in China.
     Alipay,
@@ -1183,6 +1230,7 @@ pub enum PaymentMethodType {
 
 /// Status of this notification.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 pub enum NotificationStatus {
     /// Paddle hasn't yet tried to deliver this notification.
@@ -1197,6 +1245,7 @@ pub enum NotificationStatus {
 
 /// Describes how this notification was created.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 pub enum NotificationOrigin {
     /// Notification created when a subscribed event occurred.
@@ -1207,6 +1256,7 @@ pub enum NotificationOrigin {
 
 /// Where notifications should be sent for this destination.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 pub enum NotificationSettingType {
     /// Deliver to an email address.
@@ -1217,6 +1267,7 @@ pub enum NotificationSettingType {
 
 /// Whether Paddle should deliver real platform events, simulation events or both to this notification destination.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 pub enum TrafficSource {
     /// Deliver real platform events to this notification destination.
@@ -1229,8 +1280,10 @@ pub enum TrafficSource {
 
 /// Operator to use when filtering.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 #[serde(rename_all = "lowercase")]
+#[cfg_attr(feature = "strum", strum(rename_all = "lowercase"))]
 pub enum FilterOperator {
     /// Less than.
     Lt,
@@ -1239,8 +1292,10 @@ pub enum FilterOperator {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
 pub enum TransactionOrigin {
     /// Transaction created via the Paddle API.
     Api,
@@ -1260,8 +1315,10 @@ pub enum TransactionOrigin {
 ///
 /// Reports are created as `pending` initially, then move to `ready` when they're available to download.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
 pub enum ReportStatus {
     /// Report created, but Paddle is processing it. It's not yet ready for download.
     Pending,
@@ -1275,8 +1332,10 @@ pub enum ReportStatus {
 
 /// Field name to filter by.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
 pub enum AdjustmentsReportFilterName {
     /// Filter by adjustment action. Pass an array of strings containing any valid value for the `action` field against an adjustment.
     Action,
@@ -1290,8 +1349,10 @@ pub enum AdjustmentsReportFilterName {
 
 /// Field name to filter by.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
 pub enum DiscountsReportFilterName {
     /// Filter by discount type. Pass an array of strings containing any valid value for the `type` field against a discount.
     Type,
@@ -1303,8 +1364,10 @@ pub enum DiscountsReportFilterName {
 
 /// Field name to filter by.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
 pub enum BalanceReportFilterName {
     /// Filter by discount updated date. Pass an RFC 3339 datetime string.
     UpdatedAt,
@@ -1312,8 +1375,10 @@ pub enum BalanceReportFilterName {
 
 /// Field name to filter by.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
 pub enum ProductPricesReportFilterName {
     /// Filter by product status. Pass an array of strings containing any valid value for the `status` field against a product.
     ProductStatus,
@@ -1331,8 +1396,10 @@ pub enum ProductPricesReportFilterName {
 
 /// Field name to filter by.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
 pub enum TransactionsReportFilterName {
     /// Filter by collection mode. Pass an array of strings containing any valid value for the `collection_mode` field against a transaction.
     CollectionMode,
@@ -1348,8 +1415,10 @@ pub enum TransactionsReportFilterName {
 
 /// Type of report.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
 pub enum AdjustmentsReportType {
     /// Adjustments reports contain information about refunds, credits, and chargebacks.
     Adjustments,
@@ -1363,8 +1432,10 @@ impl ReportType for AdjustmentsReportType {
 
 /// Type of report.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
 pub enum TransactionsReportType {
     /// Transactions reports contain information about revenue received, past due invoices, draft and issued invoices, and canceled transactions.
     Transactions,
@@ -1378,8 +1449,10 @@ impl ReportType for TransactionsReportType {
 
 /// Type of report.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
 pub enum ProductsAndPricesReportType {
     /// Products and prices reports contain information about your products and prices. May include non-catalog products and prices.
     ProductsPrices,
@@ -1391,8 +1464,10 @@ impl ReportType for ProductsAndPricesReportType {
 
 /// Type of report.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
 pub enum DiscountsReportType {
     /// Discounts reports contain information about your product and checkout discounts.
     Discounts,
@@ -1404,8 +1479,10 @@ impl ReportType for DiscountsReportType {
 
 /// Type of report.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
 pub enum BalanceReportType {
     /// Balance reports contain information about your account balance activity, including all movements of funds in and out of your balance.
     Balance,
@@ -1417,6 +1494,7 @@ impl ReportType for BalanceReportType {
 
 /// Status of this simulation run log.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 pub enum SimulationEventStatus {
     /// Simulation run log is pending. Paddle hasn't yet tried to deliver the simulated event.
@@ -1431,6 +1509,7 @@ pub enum SimulationEventStatus {
 
 /// Status of this simulation run.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 pub enum SimulationRunStatus {
     /// Simulation run is pending. Paddle is sending events that are part of this simulation.
@@ -1443,6 +1522,7 @@ pub enum SimulationRunStatus {
 
 /// Scenario for a simulation.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 pub enum SimulationScenarioType {
     /// Simulates all events sent when a subscription is created.
@@ -1459,6 +1539,7 @@ pub enum SimulationScenarioType {
 
 /// Type of simulation.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 pub enum SimulationKind {
     /// Paddle simulates a single event.
@@ -1469,8 +1550,10 @@ pub enum SimulationKind {
 
 /// Status of this payment attempt.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
 pub enum PaymentAttemptStatus {
     /// Authorized but not captured. Payment attempt is incomplete.
     Authorized,
@@ -1496,8 +1579,10 @@ pub enum PaymentAttemptStatus {
 
 /// Status of this subscription. Set automatically by Paddle. Use the pause subscription or cancel subscription operations to change.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
 pub enum SubscriptionStatus {
     /// Subscription is active. Paddle is billing for this subscription and related transactions aren't past due.
     Active,
@@ -1513,8 +1598,10 @@ pub enum SubscriptionStatus {
 
 /// Status of this transaction. You may set a transaction to `billed` or `canceled`, other statuses are set automatically by Paddle. Automatically-collected transactions may return `completed` if payment is captured successfully, or `past_due` if payment failed.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
 pub enum TransactionStatus {
     /// Transaction is missing required fields. Typically the first stage of a checkout before customer details are captured.
     Draft,
@@ -1534,8 +1621,10 @@ pub enum TransactionStatus {
 
 /// Kind of change that's scheduled to be applied to this subscription.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 #[serde(rename_all = "lowercase")]
+#[cfg_attr(feature = "strum", strum(rename_all = "lowercase"))]
 pub enum ScheduledChangeAction {
     /// Subscription is scheduled to cancel. Its status changes to `canceled` on the `effective_at` date.
     Cancel,
@@ -1547,8 +1636,10 @@ pub enum ScheduledChangeAction {
 
 /// How Paddle should handle changes made to a subscription or its items if the payment fails during update. If omitted, defaults to `prevent_change`.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
 pub enum SubscriptionOnPaymentFailure {
     /// In case of payment failure, prevent the change to the subscription from applying.
     PreventChange,
@@ -1558,8 +1649,10 @@ pub enum SubscriptionOnPaymentFailure {
 
 /// Whether the subscription change results in a prorated credit or a charge.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 #[serde(rename_all = "lowercase")]
+#[cfg_attr(feature = "strum", strum(rename_all = "lowercase"))]
 pub enum UpdateSummaryResultAction {
     /// Changes to the subscription results in a prorated credit.
     Credit,
@@ -1573,8 +1666,10 @@ pub enum UpdateSummaryResultAction {
 /// For automatically-collected subscriptions, responses may take longer than usual if a proration billing mode that
 /// collects for payment immediately is used.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
 pub enum ProrationBillingMode {
     /// Paddle calculates the prorated amount for the subscription changes based on the current billing cycle, then
     /// creates a transaction to collect immediately.
@@ -1594,8 +1689,10 @@ pub enum ProrationBillingMode {
 
 /// How Paddle should set the billing period for the subscription when resuming. If omitted, defaults to `start_new_billing_period`.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
 pub enum SubscriptionOnResume {
     /// When resuming, continue the existing billing period. If the customer resumes before the end date of the existing billing period, there's no immediate charge. If after, an error is returned.
     ContinueExistingBillingPeriod,
@@ -1605,8 +1702,10 @@ pub enum SubscriptionOnResume {
 
 /// Determine whether the generated URL should download the PDF as an attachment saved locally, or open it inline in the browser.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 #[serde(rename_all = "lowercase")]
+#[cfg_attr(feature = "strum", strum(rename_all = "lowercase"))]
 pub enum Disposition {
     /// Generated URL downloads the PDF as an attachment. Browsers typically automatically save the PDF.
     Attachment,
@@ -1615,8 +1714,10 @@ pub enum Disposition {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 #[serde(rename_all = "lowercase")]
+#[cfg_attr(feature = "strum", strum(rename_all = "lowercase"))]
 pub enum PayoutStatus {
     /// Payout is paid.
     Paid,
@@ -1625,8 +1726,10 @@ pub enum PayoutStatus {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[non_exhaustive]
 #[serde(rename_all = "lowercase")]
+#[cfg_attr(feature = "strum", strum(rename_all = "lowercase"))]
 pub enum ApiKeyStatus {
     Active,
     Expired,
@@ -1635,7 +1738,9 @@ pub enum ApiKeyStatus {
 
 /// Include related entities in the response.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumString, Display))]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "strum", strum(rename_all = "snake_case"))]
 #[non_exhaustive]
 pub enum SubscriptionInclude {
     /// Include an object with a preview of the next transaction for this subscription. May include prorated charges that aren't yet billed and one-time charges.


### PR DESCRIPTION
- Adds an optional strum feature to add Display and EnumString to all unit enums
- Add Copy to all unit enums

I am wondering if we should improve forward compatibility by adding an `Other(String)`. Specially for currency codes those might change.