### PR TITLE
feat: allow configuring reqwest tls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,9 @@ edition = "2021"
 doctest = false
 
 [dependencies]
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.12", default-features = false, features = [
+  "charset", "http2", "system-proxy", "json",
+] }
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -28,3 +30,10 @@ strum = { version = ">=0.26,<0.28", features = ["derive"], optional = true }
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
 actix-web = "4"
+
+[features]
+default = ["native-certs"]
+
+native-certs = ["reqwest/native-tls"]
+rustls-native-roots = ["reqwest/rustls-tls-native-roots"]
+rustls-webpki-roots = ["reqwest/rustls-tls-webpki-roots"]


### PR DESCRIPTION
As part of my application, I need to not depend on the system's `openssl` through `pkg-config`. `reqwest` allows using `rustls` instead, but it must be enabled through feature flags. This PR adds feature flags to pass to `reqwest`, and the `default` features keep the behavior the same as before.