### PR TITLE
Forward strum feature to types crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ actix-web = "4"
 
 [features]
 default = ["native-certs"]
+strum = ["dep:strum", "paddle-rust-sdk-types/strum"]
 
 native-certs = ["reqwest/native-tls"]
 rustls-native-roots = ["reqwest/rustls-tls-native-roots"]


### PR DESCRIPTION
I was not able to use FromStr for CountryCodeSupported without importing the paddle-rust-sdk-types crate with the strum feature. This PR forwards the strum feature that was already implicity present to the types crate.